### PR TITLE
Adds compatibility for Django 2.0 

### DIFF
--- a/partial_index/__init__.py
+++ b/partial_index/__init__.py
@@ -47,7 +47,7 @@ class PartialIndex(Index):
         self.where = where
         self.where_postgresql = where_postgresql
         self.where_sqlite = where_sqlite
-        super(PartialIndex, self).__init__(fields, name)
+        super(PartialIndex, self).__init__(fields=fields, name=name)
 
     def __repr__(self):
         if self.where:


### PR DESCRIPTION
In Django 2.0, positional arguments are no longer accepted by model.Index.  With this tiny change django-partial-index is now Django 2.0 compatible.
