### PR TITLE
Allow NULL on unique fields to be non-unique in forms

### DIFF
--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -6,8 +6,8 @@ import datetime
 from django.core.exceptions import ImproperlyConfigured
 from django.test import TransactionTestCase
 
-from testapp.forms import RoomBookingAllFieldsForm, RoomBookingNoConditionFieldForm, RoomBookingJustRoomForm, RoomBookingTextForm
-from testapp.models import User, Room, RoomBookingQ
+from testapp.forms import RoomBookingAllFieldsForm, RoomBookingNoConditionFieldForm, RoomBookingJustRoomForm, RoomBookingTextForm, NullableRoomNumberAllFieldsForm
+from testapp.models import User, Room, RoomBookingQ, NullableRoomNumberQ
 
 
 class OnlyQTestCase(TransactionTestCase):
@@ -93,3 +93,63 @@ class SingleFieldFormTest(FormTestCase, TransactionTestCase):
     These have to be provided from an existing instance.
     """
     formclass = RoomBookingJustRoomForm
+
+
+class NullableFieldFormTest(TransactionTestCase):
+    """Test that partial unique validation on a ModelForm treats null values as non-unique."""
+    formclass = NullableRoomNumberAllFieldsForm
+    conflict_error = 'NullableRoomNumberQ with the same values for room, room_number already exists.'
+
+    def setUp(self):
+        self.room1 = Room.objects.create(name='Room1')
+        self.room2 = Room.objects.create(name='Room2')
+        self.number1_1 = NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+        self.number1_2 = NullableRoomNumberQ.objects.create(room=self.room1, room_number=2)
+        self.number2_1 = NullableRoomNumberQ.objects.create(room=self.room2, room_number=1)
+        self.number2_none = NullableRoomNumberQ.objects.create(room=self.room2, room_number=None)
+
+    def test_add_duplicate_invalid(self):
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 1})
+        self.assertFalse(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertIn(self.conflict_error, form.errors['__all__'])
+
+    def test_add_duplicate_when_deleted_valid(self):
+        self.number1_1.deleted_at = datetime.datetime.utcnow()
+        self.number1_1.save()
+        
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 1})
+        self.assertTrue(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertFalse(form.errors)
+
+    def test_add_non_duplicate_valid(self):
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 3})
+        self.assertTrue(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertFalse(form.errors)
+
+    def test_modify_existing_valid(self):
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 3}, instance=self.number1_1)
+        self.assertTrue(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertFalse(form.errors)
+
+    def test_modify_another_to_be_duplicate_on_fk_invalid(self):
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 1}, instance=self.number2_1)
+        self.assertFalse(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertIn(self.conflict_error, form.errors['__all__'])
+
+    def test_modify_another_to_be_duplicate_on_integer_invalid(self):
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 2}, instance=self.number1_1)
+        self.assertFalse(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertIn(self.conflict_error, form.errors['__all__'])
+
+    def test_modify_another_to_be_duplicate_on_nulled_field_valid(self):
+        form = self.formclass(data={'room': self.room2.id, 'room_number': None}, instance=self.number2_1)
+        self.assertTrue(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertFalse(form.errors)
+
+    def test_modify_another_to_be_duplicate_when_deleted_valid(self):
+        self.number1_1.deleted_at = datetime.datetime.utcnow()
+        self.number1_1.save()
+
+        form = self.formclass(data={'room': self.room1.id, 'room_number': 1}, instance=self.number2_none)
+        self.assertTrue(form.is_valid(), 'Form errors: %s' % form.errors)
+        self.assertFalse(form.errors)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -5,7 +5,7 @@ from django.db import IntegrityError
 from django.test import TransactionTestCase
 from django.utils import timezone
 
-from testapp.models import User, Room, RoomBookingText, JobText, ComparisonText, RoomBookingQ, JobQ, ComparisonQ
+from testapp.models import User, Room, RoomBookingText, JobText, ComparisonText, NullableRoomNumberText, RoomBookingQ, JobQ, ComparisonQ, NullableRoomNumberQ
 
 
 class PartialIndexRoomBookingTest(TransactionTestCase):
@@ -137,3 +137,63 @@ class PartialIndexComparisonTest(TransactionTestCase):
     def test_comparison_q_duplicate_different_numbers(self):
         ComparisonQ.objects.create(a=1, b=2)
         ComparisonQ.objects.create(a=1, b=2)
+
+
+class PartialIndexRoomNumberTest(TransactionTestCase):
+    """Test that partial unique constraints work as expected when inserting data to the db.
+
+    Models and indexes are created when django creates the test db, they do not need to be set up.
+    """
+
+    def setUp(self):
+        self.room1 = Room.objects.create(name='Room1')
+        self.room2 = Room.objects.create(name='Room2')
+
+    def test_nullable_roomnumber_text_different_rooms(self):
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=1)
+        NullableRoomNumberText.objects.create(room=self.room2, room_number=1)
+
+    def test_nullable_roomnumber_q_different_rooms(self):
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+        NullableRoomNumberQ.objects.create(room=self.room2, room_number=1)
+
+    def test_nullable_roomnumber_text_different_room_numbers(self):
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=1)
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=2)
+
+    def test_nullable_roomnumber_q_different_users(self):
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=2)
+
+    def test_nullable_roomnumber_text_same_mark_first_deleted(self):
+        for i in range(3):
+            nr = NullableRoomNumberText.objects.create(room=self.room1, room_number=1)
+            nr.deleted_at = timezone.now()
+            nr.save()
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=1)
+
+    def test_nullable_roomnumber_q_same_mark_first_deleted(self):
+        for i in range(3):
+            nr = NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+            nr.deleted_at = timezone.now()
+            nr.save()
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+
+    def test_nullable_roomnumber_text_same_conflict(self):
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=1)
+        with self.assertRaises(IntegrityError):
+            NullableRoomNumberText.objects.create(room=self.room1, room_number=1)
+
+    def test_nullable_roomnumber_q_same_conflict(self):
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+        with self.assertRaises(IntegrityError):
+            NullableRoomNumberQ.objects.create(room=self.room1, room_number=1)
+
+
+    def test_nullable_roomnumber_text_same_no_conflict_for_null_number(self):
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=None)
+        NullableRoomNumberText.objects.create(room=self.room1, room_number=None)
+
+    def test_nullable_roomnumber_q_same_no_conflict_for_null_number(self):
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=None)
+        NullableRoomNumberQ.objects.create(room=self.room1, room_number=None)

--- a/tests/testapp/forms.py
+++ b/tests/testapp/forms.py
@@ -1,7 +1,7 @@
 """ModelForms for testing ValidatePartialUniqueMixin."""
 from django import forms
 
-from testapp.models import RoomBookingQ, RoomBookingText
+from testapp.models import RoomBookingQ, RoomBookingText, NullableRoomNumberQ
 
 
 class RoomBookingTextForm(forms.ModelForm):
@@ -30,3 +30,10 @@ class RoomBookingJustRoomForm(forms.ModelForm):
     class Meta:
         model = RoomBookingQ
         fields = ('room', )
+
+
+class NullableRoomNumberAllFieldsForm(forms.ModelForm):
+    """All fields are present on the form."""
+    class Meta:
+        model = NullableRoomNumberQ
+        fields = ('room', 'room_number', 'deleted_at')

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -97,3 +97,21 @@ class ComparisonQ(models.Model):
         indexes = [
             PartialIndex(fields=['a', 'b'], unique=True, where=PQ(a=PF('b'))),
         ]
+
+
+class NullableRoomNumberText(ValidatePartialUniqueMixin, models.Model):
+    room = models.ForeignKey(Room, on_delete=models.CASCADE)
+    room_number = models.IntegerField(null=True, blank=True)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        indexes = [PartialIndex(fields=['room', 'room_number'], unique=True, where='deleted_at IS NULL')]
+
+
+class NullableRoomNumberQ(ValidatePartialUniqueMixin, models.Model):
+    room = models.ForeignKey(Room, on_delete=models.CASCADE)
+    room_number = models.IntegerField(null=True, blank=True)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        indexes = [PartialIndex(fields=['room', 'room_number'], unique=True, where=PQ(deleted_at__isnull=True))]


### PR DESCRIPTION
The database will allow it, but the validator incorrectly rejects NULL
values on nullable fields which are part of the unique index.

This patch fixes that so the form validations correspond to how the database index is checked.