### PR TITLE
Improve validation errors in mixin

### DIFF
--- a/partial_index/mixins.py
+++ b/partial_index/mixins.py
@@ -1,4 +1,4 @@
-from django.core.exceptions import ImproperlyConfigured, ValidationError
+from django.core.exceptions import ImproperlyConfigured, ValidationError, NON_FIELD_ERRORS
 from django.db.models import Q
 
 from .index import PartialIndex
@@ -83,7 +83,8 @@ class ValidatePartialUniqueMixin(object):
                     conflict = conflict.exclude(pk=self.pk)  # Step 4
 
                 if conflict.exists():
-                    raise PartialUniqueValidationError('%s with the same values for %s already exists.' % (
-                        self.__class__.__name__,
-                        ', '.join(sorted(idx.fields)),
-                    ))
+                    if len(idx.fields) == 1:
+                        key = idx.fields[0]
+                    else:
+                        key = NON_FIELD_ERRORS
+                    raise PartialUniqueValidationError({key: self.unique_error_message(self.__class__, sorted(idx.fields))})

--- a/tests/test_forms.py
+++ b/tests/test_forms.py
@@ -21,7 +21,7 @@ class FormTestCase(object):
     """Base class for form tests.
     """
     formclass = None
-    conflict_error = 'RoomBookingQ with the same values for room, user already exists.'
+    conflict_error = 'Room booking q with this Room and User already exists.'
 
     def setUp(self):
         self.user1 = User.objects.create(name='User1')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -207,3 +207,20 @@ class PartialIndexLabelValidationTest(TransactionTestCase):
 
         with self.assertRaises(IntegrityError):
             label.save()
+
+    def test_all_partial_constraints_are_included_in_validation_errors(self):
+        Label.objects.create(label='a', user=self.user1, room=self.room1, uuid='11111111-0000-0000-0000-000000000000', created_at='2019-01-01T11:11:11')
+
+        label = Label(label='a', user=self.user1, room=self.room1, uuid='22222222-0000-0000-0000-000000000000', created_at='2019-01-02T22:22:22')
+        with self.assertRaises(ValidationError) as cm:
+            label.full_clean()
+
+        self.assertSetEqual({NON_FIELD_ERRORS}, set(cm.exception.message_dict.keys()))
+        self.assertEqual(2, len(cm.exception.error_dict[NON_FIELD_ERRORS]))
+        self.assertEqual('unique_together', cm.exception.error_dict[NON_FIELD_ERRORS][0].code)
+        self.assertEqual(['label', 'room'], cm.exception.error_dict[NON_FIELD_ERRORS][0].params['unique_check'])
+        self.assertEqual('unique_together', cm.exception.error_dict[NON_FIELD_ERRORS][1].code)
+        self.assertEqual(['label', 'user'], cm.exception.error_dict[NON_FIELD_ERRORS][1].params['unique_check'])
+
+        with self.assertRaises(IntegrityError):
+            label.save()

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -65,7 +65,7 @@ class JobText(models.Model):
         ]
 
 
-class JobQ(models.Model):
+class JobQ(ValidatePartialUniqueMixin, models.Model):
     order = models.IntegerField()
     group = models.IntegerField()
     is_complete = models.BooleanField(default=False)

--- a/tests/testapp/models.py
+++ b/tests/testapp/models.py
@@ -97,3 +97,20 @@ class ComparisonQ(models.Model):
         indexes = [
             PartialIndex(fields=['a', 'b'], unique=True, where=PQ(a=PF('b'))),
         ]
+
+
+class Label(ValidatePartialUniqueMixin, models.Model):
+    room = models.ForeignKey(Room, on_delete=models.CASCADE, null=True, blank=True)
+    user = models.ForeignKey(User, on_delete=models.CASCADE, null=True, blank=True)
+    label = models.TextField()
+    uuid = models.UUIDField()
+    created_at = models.DateTimeField(unique=True)
+    deleted_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        indexes = [
+            PartialIndex(fields=['room', 'label'], unique=True, where=PQ(deleted_at__isnull=True)),
+            PartialIndex(fields=['user', 'label'], unique=True, where=PQ(deleted_at__isnull=True)),
+            PartialIndex(fields=['uuid'], unique=True, where=PQ(deleted_at__isnull=True)),
+        ]
+        unique_together = [['room', 'user']]  # Regardless of deletion status


### PR DESCRIPTION
This has several improvements to how validation errors are raised by the mixin:

- Use the Django built-in validation error generation to produce better errors:
    - The name of the field that triggered the validation error is used as the error dictionary key if it's a single field. This helps to highlight the field in a frontend.
    - For JSON-based APIs the `code` field is very useful to determine what is wrong with that particular field, and we rely on this in our project at work
- When there are failing "standard" uniqueness checks, do not bail out early but merge partial unique validation errors into the standard errors.
- When there are multiple partially unique indexes that trigger a uniqueness error, all errors are returned instead of just the first.

This builds on #15 so please take a look at that one first.