### PR TITLE
make compatible with django 3.0 and drop support for django < 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,39 +5,25 @@ services:
 
 matrix:
   include:
-  - python: 2.7
-    env: DJANGO_VERSION=1.11.22
-  - python: 3.4
-    env: DJANGO_VERSION=1.11.22
-  - python: 3.5
-    env: DJANGO_VERSION=1.11.22
-  - python: 3.6
-    env: DJANGO_VERSION=1.11.22
-  - python: 3.7
-    env: DJANGO_VERSION=1.11.22
-
-  - python: 3.4
-    env: DJANGO_VERSION=2.0.13
-  - python: 3.5
-    env: DJANGO_VERSION=2.0.13
-  - python: 3.6
-    env: DJANGO_VERSION=2.0.13
-  - python: 3.7
-    env: DJANGO_VERSION=2.0.13
 
   - python: 3.5
-    env: DJANGO_VERSION=2.1.10
+    env: DJANGO_VERSION=2.2.12
   - python: 3.6
-    env: DJANGO_VERSION=2.1.10
+    env: DJANGO_VERSION=2.2.12
   - python: 3.7
-    env: DJANGO_VERSION=2.1.10
+    env: DJANGO_VERSION=2.2.12
+  - python: 3.8
+    env: DJANGO_VERSION=2.2.12
 
   - python: 3.5
-    env: DJANGO_VERSION=2.2.3
+    env: DJANGO_VERSION=3.0.6
   - python: 3.6
-    env: DJANGO_VERSION=2.2.3
+    env: DJANGO_VERSION=3.0.6
   - python: 3.7
-    env: DJANGO_VERSION=2.2.3
+    env: DJANGO_VERSION=3.0.6
+  - python: 3.8
+    env: DJANGO_VERSION=3.0.6
+
 
 install: "pip install --upgrade pip && pip install -q psycopg2 django==$DJANGO_VERSION djangorestframework==3.8.2"
 script: "./tests/runtests.py"

--- a/partial_index/__init__.py
+++ b/partial_index/__init__.py
@@ -7,7 +7,7 @@ __version__ = '.'.join(str(v) for v in VERSION)
 __all__ = ['PartialIndex', 'PQ', 'PF', 'ValidatePartialUniqueMixin', 'PartialUniqueValidationError']
 
 
-MIN_DJANGO_VERSION = (1, 11)
+MIN_DJANGO_VERSION = (2, 2)
 DJANGO_VERSION_ERROR = 'Django version %s or later is required for django-partial-index.' % '.'.join(str(v) for v in MIN_DJANGO_VERSION)
 
 try:

--- a/partial_index/index.py
+++ b/partial_index/index.py
@@ -1,5 +1,4 @@
 from django.db.models import Index, Q
-from django.utils import six
 from django.utils.encoding import force_bytes
 import hashlib
 import warnings
@@ -12,7 +11,7 @@ def validate_where(where='', where_postgresql='', where_sqlite=''):
     if where:
         if where_postgresql or where_sqlite:
             raise ValueError('If providing a common where predicate, must not provide where_postgresql or where_sqlite.')
-        if isinstance(where, six.string_types):
+        if isinstance(where, str):
             warnings.warn(
                 'Text-based where predicates are deprecated, will be removed in a future release. ' +
                 'Please upgrade to where=PQ().',
@@ -27,7 +26,7 @@ def validate_where(where='', where_postgresql='', where_sqlite=''):
         if where_postgresql == where_sqlite:
             raise ValueError('If providing a separate where_postgresql and where_sqlite, then they must be different.' +
                              'If the same expression works for both, just use single where.')
-        if not isinstance(where_postgresql, six.string_types) or not isinstance(where_sqlite, six.string_types):
+        if not isinstance(where_postgresql, str) or not isinstance(where_sqlite, str):
             raise ValueError('where_postgresql and where_sqlite must be strings.')
         warnings.warn(
             'Text-based where predicates are deprecated, will be removed in a future release. ' +
@@ -152,7 +151,6 @@ class PartialIndex(Index):
             'Index too long for multiple database support. Is self.suffix '
             'longer than 3 characters?'
         )
-        self.check_name()
 
     @staticmethod
     def _hash_generator(*args):

--- a/partial_index/index.py
+++ b/partial_index/index.py
@@ -119,7 +119,7 @@ class PartialIndex(Index):
             raise ValueError('Should never happen')
         return parameters
 
-    def create_sql(self, model, schema_editor, using=''):
+    def create_sql(self, model, schema_editor, using='', **kwargs):
         vendor = query.get_valid_vendor(schema_editor)
         sql_template = self.sql_create_index[vendor]
         sql_parameters = self.get_sql_create_template_values(model, schema_editor, using)


### PR DESCRIPTION
Following Django 3.0 [release notes](https://docs.djangoproject.com/en/3.0/releases/3.0/), I dropped support for Django < 2.2 